### PR TITLE
Nov 2022 Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Players may receive a -1 tier demotion during Promotion Day if they didn't play 
 
 If a 'Rookie' player had a reason to be demoted again, they become a candidate for booting at the next need for an available seat. We will always try to warn booted players on Discord whenever possible. We boot players according to these factors:
 
-- We prevent having more than one open seat at any given time.
+- We do not want more than one open seat at any given time.
   - Captains may use alt players to fill extra seats, as a mechanism to keep our trophy count high enough, until we can go back to a max of one open seat. When this happens, a captain must notify the team what player that is.
 - When a seat opens, captains should start with a higher trophy minimum and slowly lower it the longer the seat remains unfilled.
 - We prioritize inviting prior team members back, who didn't leave due to negative behaviors, so long as their trophy count is within -200 trophies of what the current trophy minimum is.

--- a/README.md
+++ b/README.md
@@ -3,38 +3,46 @@
 The below four rules are actually rules. We expect all team members to follow these rules at all times either on the game or [on our Discord](https://discord.gg/RGzcnXfWhv).
 
 ## 1. Be friendly to our team ❤️
-Do not attack another teammate. This includes bullying, harassment, cursing, misleading, or rudeness towards another teammate. If there are any concerns, DM a captain or talk about it constructively. If a majority of active captains agreed you violated this rule, _even if the other side was at fault too_, you will be demoted or booted.
+
+- You will be demoted or booted if 3+ active captains determined that you attacked another teammate. This includes bullying, harassment, cursing, misleading, or rudeness towards another teammate, _even if the other side was at fault too_.
+- You will be asked to stop if 3+ active captains determined you did something that wasn't appropriate or beneficial for our community. This includes abusing your team role, disobeying a captain, or doing something which was illegal, NSFW, or discriminatory. We are more strict on the in-game chat, to comply with Noodlecake's TOS. If you continue not to stop after we asked you to, you will be demoted or booted.
+
+You can report any issues by [DM'ing a captain on Discord](https://discord.gg/RGzcnXfWhv) or by submitting a report on our [Homepage](https://linktr.ee/3pfl). 
 
  ## 2. Promotions Guidelines 📈
 Once a week (on a randomly selected day) we will promote eligible players by +1 Tier. Promotions are done to encourage activity & appropriate behaviors. Players are eligible for promotion if they fulfill ALL of these:
 
-- Was active during the past 7 days.
+- Was on the team and active during the past 7 days.
 - Met the current trophy min or is above 1700, whichever is lower.
-- Did not recently violate any of the other rules.
-- To go from Amateur to Pro: In addition to the above, you must be on Discord. Once you're a Pro, you can request a free physical team sticker (details are in the next post)
+- Did not recently violate Rule #1.
+- To go from Amateur to Pro: Must be on the 3PFL Discord. (p.s. once you're a Pro, you can request a free physical team sticker.)
 - To go from Pro to Co-Captains: These are done rarely, on an invite basis for players who've made exceptional contributions to the team.
 
 ## 3. Demotion + Boot Guidelines 😞
-Players may receive a -1 tier demotion during Promotion Day if they didn't play _and_ wasn't interacting with the team during the past 7 days. This in addition to the guidance in Rules 1 + 4. If a 'Rookie' player had a reason to be demoted again, they become a candidate for booting at the next need for an available seat. 
+Players may receive a -1 tier demotion during Promotion Day if they didn't play _or_ wasn't active during the past 7 days. Players may be demoted or booted out of turn if they violated Rule #1.
 
-## 4. Be a Positive Contributor 😎
-Don't say anything that is illegal, NSFW, discriminatory, or otherwise isn’t appropriate/beneficial for our community. Furthermore, do not misuse any team roles you have or disobey a captain. These standards are even more strict on the in-game chat, to comply with Noodlecake's TOS. If a majority of the active captains agreed that you violated this rule, we will ask you to stop. If you repeat it, you may be demoted and/or booted.
+If a 'Rookie' player had a reason to be demoted again, they become a candidate for booting at the next need for an available seat. We will always try to warn booted players on Discord whenever possible. We boot players according to these factors:
 
-## 5. Stickers for Pros :love_letter: **__
+- We prevent having more than one open seat at any given time.
+  - Captains may use alt players to fill extra seats, as a mechanism to keep our trophy count high enough, until we can go back to a max of one open seat. When this happens, a captain must notify the team what player that is.
+- When a seat opens, captains should start with a higher trophy minimum and slowly lower it the longer the seat remains unfilled.
+- We prioritize inviting prior team members back, who didn't leave due to negative behaviors, so long as their trophy count is within -200 trophies of what the current trophy minimum is.
+
+## 4. Stickers for Pros 💌
 Players who became Pro for the first time are eligible to request a free sticker of our team logo mailed out. Fill out [the form at our homepage](https://linktr.ee/3pfl) to request a sticker.
 
 # 3 Putt for Life Best Practices
 
 These are not rules, because frankly, there's no way us captains or co-captains could enforce these with certainty. But, there are some best practices we kindly ask you to follow, whenever possible.
 
-## 6. Trade cards the team needs 🧢
+## 5. Trade cards the team needs 🧢
 Please try to sell cards that either someone else is asking for or cards which are low in stock in the store. Remember to consider trading Hat cards, which traditionally, are low in stock.
 
-## 7. In a Trophy game where all players are teammates, try to tie 🤝
+## 6. In a Trophy game where all players are teammates, try to tie 🤝
 In a 2 player trophy game, both players may opt to throw the match so nobody loses trophies. To propose doing this, both team players must spam the 'Nooo' emoji three times. If some players do not respond, this rule is **not** active and it's game on. It is however against the rules for both players to say 'Noo' and for one player to use that opportunity to backstab the other player into an easy win.
 
-## 8. Don't give us a reason to change the rules because of you 🌭
+## 7. Don't give us a reason to change the rules because of you 🌭
 If you're testing the Team Rules to see how far you can go, brace yourself for disappointment just like meeting a fellow person who believes the hotdog is a sandwich. These rules can change at anytime with no warning to protect a friendly & active team environment.
 
-## 9. Questions? Feedback? 💬
+## 8. Questions? Feedback? 💬
 You are always welcome and encouraged to chat with a captain or co-captain if you have questions or feedback. You can do that [on Discord](https://discord.gg/RGzcnXfWhv) or via our [Homepage](https://linktr.ee/3pfl)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The below four rules are actually rules. We expect all team members to follow th
 ## 1. Be friendly to our team ❤️
 
 - You will be demoted or booted if 3+ active captains determined that you attacked another teammate. This includes bullying, harassment, cursing, misleading, or rudeness towards another teammate, _even if the other side was at fault too_.
-- You will be asked to stop if 3+ active captains determined you did something that wasn't appropriate or beneficial for our community. This includes abusing your team role, disobeying a captain, or doing something which was illegal, NSFW, or discriminatory. We are more strict on the in-game chat, to comply with Noodlecake's TOS. If you continue not to stop after we asked you to, you will be demoted or booted.
+- You will be asked to stop if 3+ active captains determined you did something that wasn't appropriate or beneficial for our community. This includes abusing your team role, disobeying a captain, or doing something which was illegal, NSFW, or discriminatory. We are more strict on the in-game chat, to comply with Noodlecake's TOS. If you continue after we asked you to stop, you will be demoted or booted.
 
 You can report any issues by [DM'ing a captain on Discord](https://discord.gg/RGzcnXfWhv) or by submitting a report on our [Homepage](https://linktr.ee/3pfl). 
 


### PR DESCRIPTION
**Rules about not being a jerk**
- Merged Rules 1 (be kind to the team) and Rules 4 (don't say anything illegal/NSFW) together.
- Updated the new Rule 1 so that if 3 captains agreed a mess up happened, that's enough. Previously this was a majority vote which I was worried could delay our ability to respond if a player was actively messing something up live.

**Rules about Promotion**
- Clarified that promotion requires a member to be on the team for the past 7 days.

**Rules about Demotion/Booting**
Added guidance for how we boot players and how we deal with open seats. Which are...

- We do not want more than one open seat at any given time.
  - Captains may use alt players to fill extra seats, as a mechanism to keep our trophy count high enough, until we can go back to a max of one open seat. When this happens, a captain must notify the team what player that is.
- When a seat opens, captains should start with a higher trophy minimum and slowly lower it the longer the seat remains unfilled.
- We prioritize inviting prior team members back, who didn't leave due to negative behaviors, so long as their trophy count is within -200 trophies of what the current trophy minimum is.